### PR TITLE
notify #-qa for qa.d.o bugs

### DIFF
--- a/bot-config/BTS.conf.in
+++ b/bot-config/BTS.conf.in
@@ -763,8 +763,8 @@ supybot.plugins.DebianDevelChanges.package_regex.#debian-lists: /^lists\.debian\
 supybot.plugins.DebianDevelChanges.package_regex.#debian-mirrors: /^mirrors$/
 # Approved by gregoa, ansgar
 supybot.plugins.DebianDevelChanges.package_regex.#pet-devel: /^pet\.debian\.net$/
-# Rejected by jcristau
-#supybot.plugins.DebianDevelChanges.package_regex.#debian-qa: /^(qa|piuparts)\.debian\.org$/
+# Requested by mapreri
+supybot.plugins.DebianDevelChanges.package_regex.#debian-qa: /^qa\.debian\.org$/
 # Deletion of press pseudo-package suggested
 #supybot.plugins.DebianDevelChanges.package_regex.#debian-publicity: /^press$/
 #Approved by Cnote, pabs


### PR DESCRIPTION
I've messaged #debian-qa about this some days ago, and nobody complained.  jcristau in particular said "wouldn't object to bug notifications today if people want them" and mentioned that his refusal at the time was because the VCS notifications where particularly bad.

Not to mention, #-qa these days has so many other kind of notifications, the very few about the qa.d.o bugs would not even make a dent on the number of messages...