### PR TITLE
Add #debian-rust

### DIFF
--- a/bot-config/BTS.conf.in
+++ b/bot-config/BTS.conf.in
@@ -63,7 +63,7 @@ supybot.networks.oftc.servers: irc.oftc.net:6697
 #
 # Default value:  
 ###
-supybot.networks.oftc.channels: #debbugs #debian-backports #debian-cd #debian-cloud #debian-devel-changes #debian-doc #debian-haskell #debian-i18n #debian-it #debian-lists #debian-live #debian-mirrors #debian-publicity #debian-sayhi #debian-wuglug #debian-www #devscripts #emdebian #pet-devel #debian-perl #debian-multimedia #debian-gis #debian-django #debian-reproducible #pbuilder #debian-python-changes #debian-openstack-commits #debian-dpkg #debian-systemd #debian-apt #debian-clojure #debian-qa #reproducible-builds #debian-til
+supybot.networks.oftc.channels: #debbugs #debian-backports #debian-cd #debian-cloud #debian-devel-changes #debian-doc #debian-haskell #debian-i18n #debian-it #debian-lists #debian-live #debian-mirrors #debian-publicity #debian-sayhi #debian-wuglug #debian-www #devscripts #emdebian #pet-devel #debian-perl #debian-multimedia #debian-gis #debian-django #debian-reproducible #pbuilder #debian-python-changes #debian-openstack-commits #debian-dpkg #debian-systemd #debian-apt #debian-clojure #debian-qa #reproducible-builds #debian-til #debian-rust
 
 ###
 # Determines what key (if any) will be used to join the channel.
@@ -803,6 +803,8 @@ supybot.plugins.DebianDevelChanges.package_regex.#debian-clojure: /.*clojure.*/
 supybot.plugins.DebianDevelChanges.package_regex.#debian-qa: /^lintian$/
 # Requested by lamby
 supybot.plugins.DebianDevelChanges.package_regex.#reproducible-builds: /^diffoscope$/
+# Requested by kpcyrd
+supybot.plugins.DebianDevelChanges.package_regex.#debian-rust: /^(librust-|rust-)/
 
 ###
 # Determines which maintainer announcements should be printed to the


### PR DESCRIPTION
As discussed in #debian-rust and #debian-devel, this sends notifications to the debian rust maintainers team.