### PR TITLE
Add team+openstack@tracker.d.o for posts in #debian-openstack-commits

### DIFF
--- a/bot-config/BTS.conf.in
+++ b/bot-config/BTS.conf.in
@@ -825,7 +825,7 @@ supybot.plugins.DebianDevelChanges.maintainer_regex.#debian-reproducible: /^repr
 # Requested by onovy
 supybot.plugins.DebianDevelChanges.maintainer_regex.#debian-python-changes: /^python-(modules-team|apps-team)@lists\.alioth\.debian\.org$/
 # Requested by onovy
-supybot.plugins.DebianDevelChanges.maintainer_regex.#debian-openstack-commits: /^openstack-devel@lists\.alioth\.debian\.org$/
+supybot.plugins.DebianDevelChanges.maintainer_regex.#debian-openstack-commits: /^(openstack-devel@lists\.alioth\.debian\.org|team\+openstack@tracker\.debian\.org)$/
 # Requested by guillem
 supybot.plugins.DebianDevelChanges.maintainer_regex.#debian-dpkg: /^debian-dpkg@lists\.debian\.org$/
 # Requested by fsateler


### PR DESCRIPTION
Hi. Since our move to the new maintainer email, the bot doesn't post anymore in our channel. Please add this address to the config.