### PR TITLE
Configure the bot for the pkg-security team

### DIFF
--- a/bot-config/BTS.conf.in
+++ b/bot-config/BTS.conf.in
@@ -63,7 +63,7 @@ supybot.networks.oftc.servers: irc.oftc.net:6697
 #
 # Default value:  
 ###
-supybot.networks.oftc.channels: #debbugs #debian-backports #debian-cd #debian-cloud #debian-devel-changes #debian-doc #debian-haskell #debian-i18n #debian-it #debian-lists #debian-live #debian-mirrors #debian-publicity #debian-sayhi #debian-wuglug #debian-www #devscripts #emdebian #pet-devel #debian-perl #debian-multimedia #debian-gis #debian-django #debian-reproducible #pbuilder #debian-python-changes #debian-openstack-commits #debian-dpkg #debian-systemd #debian-apt #debian-clojure #debian-qa #reproducible-builds #debian-til #debian-rust
+supybot.networks.oftc.channels: #debbugs #debian-backports #debian-cd #debian-cloud #debian-devel-changes #debian-doc #debian-haskell #debian-i18n #debian-it #debian-lists #debian-live #debian-mirrors #debian-publicity #debian-sayhi #debian-wuglug #debian-www #devscripts #emdebian #pet-devel #debian-perl #debian-multimedia #debian-gis #debian-django #debian-reproducible #pbuilder #debian-python-changes #debian-openstack-commits #debian-dpkg #debian-systemd #debian-apt #debian-clojure #debian-qa #reproducible-builds #debian-til #debian-rust #debian-pkg-security
 
 ###
 # Determines what key (if any) will be used to join the channel.
@@ -834,6 +834,8 @@ supybot.plugins.DebianDevelChanges.maintainer_regex.#debian-systemd: /^pkg-syste
 supybot.plugins.DebianDevelChanges.maintainer_regex.#debian-apt: /^(deity@lists\.debian\.org|aptitude-devel@lists\.alioth\.debian\.org)$/
 # Requested by Clint
 supybot.plugins.DebianDevelChanges.maintainer_regex.#debian-clojure: /^pkg-clojure-maintainers@lists\.alioth\.debian\.org$/
+# Approved by buxy
+supybot.plugins.DebianDevelChanges.maintainer_regex.#debian-pkg-security: /^(team\+pkg-security@tracker\.debian\.org|(pkg-security-team|forensics-devel)@lists\.alioth\.debian\.org)$/
 
 ###
 # Determines which distribution announcements should be printed to the


### PR DESCRIPTION
The pkg-security team currently has 3 maintainer emails in use... we merged two Alioth teams in a single Salsa team.