### PR TITLE
add notifications for #debian-java-changes

### DIFF
--- a/bot-config/BTS.conf.in
+++ b/bot-config/BTS.conf.in
@@ -63,7 +63,7 @@ supybot.networks.oftc.servers: irc.oftc.net:6697
 #
 # Default value:  
 ###
-supybot.networks.oftc.channels: #debbugs #debian-backports #debian-cd #debian-cloud #debian-devel-changes #debian-doc #debian-haskell #debian-i18n #debian-it #debian-lists #debian-live #debian-mirrors #debian-publicity #debian-sayhi #debian-wuglug #debian-www #devscripts #emdebian #pet-devel #debian-perl #debian-multimedia #debian-newmaint #debian-gis #debian-django #debian-reproducible #pbuilder #debian-python-changes #debian-openstack-commits #debian-dpkg #debian-systemd #debian-apt #debian-clojure #debian-qa #reproducible-builds #debian-til #debian-rust #debian-pkg-security #debian-kbsd #debian-js #debian-swaywm #debian-puppet
+supybot.networks.oftc.channels: #debbugs #debian-backports #debian-cd #debian-cloud #debian-devel-changes #debian-doc #debian-haskell #debian-i18n #debian-it #debian-lists #debian-live #debian-mirrors #debian-publicity #debian-sayhi #debian-wuglug #debian-www #devscripts #emdebian #pet-devel #debian-perl #debian-multimedia #debian-newmaint #debian-gis #debian-django #debian-reproducible #pbuilder #debian-python-changes #debian-openstack-commits #debian-dpkg #debian-systemd #debian-apt #debian-clojure #debian-qa #reproducible-builds #debian-til #debian-rust #debian-pkg-security #debian-kbsd #debian-js #debian-swaywm #debian-puppet #debian-java-changes
 
 ###
 # Determines what key (if any) will be used to join the channel.
@@ -809,6 +809,8 @@ supybot.plugins.DebianDevelChanges.package_regex.#debian-js: /^(libjs-.*|node(js
 supybot.plugins.DebianDevelChanges.package_regex.#debian-systemd: /^usrmerge$/
 # Requested by lavamind
 supybot.plugins.DebianDevelChanges.package_regex.#debian-puppet: /^(hiera(-.*)|facter|librarian-puppet|puppet(-agent|-lint|-module|-strings|db|server)|ruby-puppet.*|r10k)/
+# Requested by lavamind
+supybot.plugins.DebianDevelChanges.package_regex.#debian-java-changes: /^(.*-java|*.-maven-plugin|default-(jdk|jre)|gradle|jakarta-|java-|jetty|jnr-|jruby|openjdk|maven|tomcat)/
 
 ###
 # Determines which maintainer announcements should be printed to the
@@ -848,6 +850,8 @@ supybot.plugins.DebianDevelChanges.maintainer_regex.#debian-kbsd: /^debian-bsd@l
 supybot.plugins.DebianDevelChanges.maintainer_regex.#debian-js: /^pkg-javascript-devel@lists\.alioth\.debian\.org$/
 # Requested by birger
 supybot.plugins.DebianDevelChanges.maintainer_regex.#debian-swaywm: /^(team\+swaywm|team\+labwc)@tracker\.debian\.org$/
+# Requested by lavamind
+supybot.plugins.DebianDevelChanges.maintainer_regex.#debian-java-changes: /^pkg-java-maintainers@lists\.alioth\.debian\.org$/
 
 ###
 # Determines which distribution announcements should be printed to the


### PR DESCRIPTION
hello, we're splitting off notifications from #debian-java to #debian-java-changes as described here:

https://lists.debian.org/debian-java/2025/07/msg00005.html

having the BTS bot join this channel would be appreciated

thanks!